### PR TITLE
Add password-based authentication

### DIFF
--- a/src/main/java/dev/memphis/sdk/MemphisConnection.java
+++ b/src/main/java/dev/memphis/sdk/MemphisConnection.java
@@ -1,8 +1,6 @@
 package dev.memphis.sdk;
 
 import dev.memphis.sdk.consumer.Consumer;
-import dev.memphis.sdk.consumer.MemphisCallbackFunction;
-import dev.memphis.sdk.consumer.MemphisConsumer;
 import dev.memphis.sdk.producer.Producer;
 import io.nats.client.Connection;
 import io.nats.client.JetStream;

--- a/src/main/java/dev/memphis/sdk/MemphisConnection.java
+++ b/src/main/java/dev/memphis/sdk/MemphisConnection.java
@@ -1,6 +1,8 @@
 package dev.memphis.sdk;
 
 import dev.memphis.sdk.consumer.Consumer;
+import dev.memphis.sdk.consumer.MemphisCallbackFunction;
+import dev.memphis.sdk.consumer.MemphisConsumer;
 import dev.memphis.sdk.producer.Producer;
 import io.nats.client.Connection;
 import io.nats.client.JetStream;
@@ -12,11 +14,13 @@ import nl.altindag.ssl.util.PemUtils;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509ExtendedKeyManager;
 import javax.net.ssl.X509ExtendedTrustManager;
-import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.Future;
 
 public class MemphisConnection {
+
+    private final Connection brokerConnection;
+    private final JetStream jetStreamContext;
 
     MemphisConnection(ClientOptions opts) throws MemphisConnectException {
         UUID uuid = UUID.randomUUID();
@@ -24,32 +28,42 @@ public class MemphisConnection {
         Options.Builder natsConnOptsBuilder = new Options.Builder()
                 .server(opts.host + ":" + opts.port)
                 .connectionName(uuid + "::" + opts.username)
-                .token(opts.broker_token.toCharArray())
-                .maxReconnects(opts.reconnect ? opts.max_reconnect : 0)
-                .reconnectWait(Duration.ofDays(opts.reconnect_interval_ms))
-                .connectionTimeout(Duration.ofDays(opts.timeout_ms));
+                .maxReconnects(opts.reconnect ? opts.maxReconnects : 0)
+                .reconnectWait(opts.reconnectInterval)
+                .connectionTimeout(opts.timeout);
+
+        if(opts.authenticationMethod instanceof ClientOptions.Password) {
+            natsConnOptsBuilder = natsConnOptsBuilder.userInfo(opts.username, opts.authenticationMethod.getString());
+        } else if(opts.authenticationMethod instanceof ClientOptions.ConnectionToken) {
+            natsConnOptsBuilder = natsConnOptsBuilder.token(opts.authenticationMethod.getString());
+        }
 
         //Third party library approach, allows using pem files
-        X509ExtendedKeyManager keyManager = PemUtils.loadIdentityMaterial(opts.cert_file, opts.key_file);
-        X509ExtendedTrustManager trustManager = PemUtils.loadTrustMaterial(opts.ca_file);
+        if(opts.sslConfiguration != null) {
+            X509ExtendedKeyManager keyManager = PemUtils.loadIdentityMaterial(opts.sslConfiguration.getCertFile(),
+                    opts.sslConfiguration.getKeyFile());
+            X509ExtendedTrustManager trustManager = PemUtils.loadTrustMaterial(opts.sslConfiguration.getCaFile());
 
-        SSLFactory sslFactory = SSLFactory.builder()
-                .withIdentityMaterial(keyManager)
-                .withTrustMaterial(trustManager)
-                .build();
-        SSLContext ssl_ctx = sslFactory.getSslContext();
-        natsConnOptsBuilder = natsConnOptsBuilder.sslContext(ssl_ctx);
+            SSLFactory sslFactory = SSLFactory.builder()
+                    .withIdentityMaterial(keyManager)
+                    .withTrustMaterial(trustManager)
+                    .build();
+            SSLContext ssl_ctx = sslFactory.getSslContext();
+            natsConnOptsBuilder = natsConnOptsBuilder.sslContext(ssl_ctx);
+        }
 
         Options natsConnOptions = natsConnOptsBuilder.build();
 
         try {
-            Connection brokerConnection = Nats.connect(natsConnOptions);
-            JetStream jetStreamContext = brokerConnection.jetStream();
+            this.brokerConnection = Nats.connect(natsConnOptions);
+            this.jetStreamContext = this.brokerConnection.jetStream();
         } catch (Exception e) {
             throw new MemphisConnectException("Error occurred while connecting to Memphis");
         }
+    }
 
-        //Todo: return Memphis
+    public void close() throws InterruptedException {
+        this.brokerConnection.close();
     }
 
     public boolean isConnected() {

--- a/src/test/java/dev/memphis/sdk/ClientOptionsTest.java
+++ b/src/test/java/dev/memphis/sdk/ClientOptionsTest.java
@@ -1,17 +1,75 @@
 package dev.memphis.sdk;
 
 import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ClientOptionsTest {
     @Test
-    public void defaultClientOptions() throws MemphisConnectException {
-        ClientOptions opts = new ClientOptions.Builder().build();
+    public void authenticateWithPassword() throws MemphisConnectException {
+        ClientOptions opts = new ClientOptions.Builder()
+                .username("username")
+                .password("password")
+                .host("host")
+                .build();
         assertEquals(opts.port, 6666);
         assertTrue(opts.reconnect);
-        assertEquals(opts.reconnect_interval_ms, 1500);
-        assertEquals(opts.timeout_ms, 1500);
-        assertEquals(opts.max_reconnect, 3);
+        assertEquals(opts.reconnectInterval, Duration.ofMillis(1500));
+        assertEquals(opts.timeout, Duration.ofMillis(1500));
+        assertEquals(opts.maxReconnects, 3);
+        assertInstanceOf(ClientOptions.Password.class, opts.authenticationMethod);
+    }
+
+    @Test
+    public void authenticateWithToken() throws MemphisConnectException {
+        ClientOptions opts = new ClientOptions.Builder()
+                .username("username")
+                .connectionToken("token")
+                .host("host")
+                .build();
+        assertEquals(opts.port, 6666);
+        assertTrue(opts.reconnect);
+        assertEquals(opts.reconnectInterval, Duration.ofMillis(1500));
+        assertEquals(opts.timeout, Duration.ofMillis(1500));
+        assertEquals(opts.maxReconnects, 3);
+        assertInstanceOf(ClientOptions.ConnectionToken.class, opts.authenticationMethod);
+    }
+
+    @Test
+    public void missingAuthentication() {
+        ClientOptions.Builder builder = new ClientOptions.Builder()
+                .host("host")
+                .username("username");
+
+        assertThrows(MemphisConnectException.class,
+                builder::build,
+                "Expected ClientOptions.Builder.build() to throw MemphisConnectionException if no password or connection token was provided");
+    }
+
+    @Test
+    public void missingHost() {
+        ClientOptions.Builder builder = new ClientOptions.Builder()
+                .password("password")
+                .username("username");
+
+        assertThrows(MemphisConnectException.class,
+                builder::build,
+                "Expected ClientOptions.Builder.build() to throw MemphisConnectionException if no host was provided");
+    }
+
+    @Test
+    public void missingUsername() {
+        ClientOptions.Builder builder = new ClientOptions.Builder()
+                .password("password")
+                .host("host");
+
+        assertThrows(MemphisConnectException.class,
+                builder::build,
+                "Expected ClientOptions.Builder.build() to throw MemphisConnectionException if no username was provided");
     }
 }


### PR DESCRIPTION
* Adds password authentication including an authentication model that supports mutually exclusivity with the connection token.
* Builder checks that host, username, and an authentication methods are provided
* Moves three ssl files into a single object
* Uses Durations instead of ints
* Changes variable names from underscores to CamelCase
* Adds tests for the builder

I tested this by checking that I can establish a connection to a Memphis broker using a username and password.
